### PR TITLE
Fix hook stop by instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ fn main() -> Result<(), winshift::WinshiftError> {
     // Start monitoring (runs in current thread)
     hook.run()?;
     
-    // On macOS, you can stop with:
-    // winshift::stop_hook();
+    // On macOS, you can stop from another thread with:
+    // hook.stop()?;
     
     Ok(())
 }
@@ -112,7 +112,7 @@ See `examples/embed_info_monitor.rs` for a complete example.
 **Important Notes**:
 
 1. Handler must be thread-safe (use Arc/RwLock if needed)
-2. On macOS, call `stop_hook()` to clean up
+2. On macOS, call `WindowFocusHook::stop()` on the instance (e.g. from a signal handler)
 3. See [examples/](examples/) for complete implementations
 4. Linux uses same API but doesn't require combined tracking
 5. Note: Implementation uses unsafe code and assumes single-threaded usage for now

--- a/examples/app_only_monitor.rs
+++ b/examples/app_only_monitor.rs
@@ -54,37 +54,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let handler = AppOnlyHandler::new();
-    let hook = WindowFocusHook::app_only(handler);
-
-    // Set up Ctrl+C handler with proper CFRunLoop termination
-    let hook_ref = Arc::new(RwLock::new(Some(hook)));
-    let hook_clone = hook_ref.clone();
+    let hook = Arc::new(WindowFocusHook::app_only(handler));
+    let stop_handle = hook.clone();
 
     ::ctrlc::set_handler(move || {
         println!("\nShutting down app-only monitor...");
         eprintln!("[SIGNAL] Ctrl+C signal received!");
 
-        // Signal CFRunLoop to stop
-        winshift::stop_hook().expect("Failed to stop hook");
+        if let Err(err) = stop_handle.stop() {
+            eprintln!("Failed to stop hook: {err}");
+        }
 
         eprintln!("[SIGNAL] Stop signal sent, exiting signal handler");
     })?;
 
     // Run the monitor on main thread (required for NSWorkspace and Accessibility API)
-    if let Ok(guard) = hook_ref.read() {
-        if let Some(ref hook) = *guard {
-            if let Err(e) = hook.run() {
-                eprintln!("Error running hook: {e}");
-            }
-        }
+    if let Err(e) = hook.run() {
+        eprintln!("Error running hook: {e}");
     }
 
-    // When hook.run() exits, clean up
     println!("App-only monitor stopped.");
-    if let Ok(mut guard) = hook_clone.write() {
-        guard.take(); // Take ownership to clean up
-    }
-
-    println!("Monitor stopped.");
     Ok(())
 }

--- a/examples/embed_info_monitor.rs
+++ b/examples/embed_info_monitor.rs
@@ -2,6 +2,7 @@
 
 #[cfg(target_os = "macos")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
     use winshift::{env_logger, FocusChangeHandler, WindowFocusHook, WindowHookConfig};
 
     env_logger::init();
@@ -42,11 +43,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
-    let hook = WindowFocusHook::with_config(handler, config);
+    let hook = Arc::new(WindowFocusHook::with_config(handler, config));
+    let stop_handle = hook.clone();
 
     // Allow Ctrl+C to stop
     let _ = ctrlc::set_handler(move || {
-        let _ = winshift::stop_hook();
+        let _ = stop_handle.stop();
     });
 
     hook.run()?;

--- a/examples/example_monitor.rs
+++ b/examples/example_monitor.rs
@@ -89,35 +89,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let handler = ExampleHandler::new();
-    let hook = WindowFocusHook::new(handler);
-
-    // Set up Ctrl+C handler with proper CFRunLoop termination
-    let hook_ref = Arc::new(RwLock::new(Some(hook)));
-    let hook_clone = hook_ref.clone();
+    let hook = Arc::new(WindowFocusHook::new(handler));
+    let stop_handle = hook.clone();
 
     ::ctrlc::set_handler(move || {
         println!("\nShutting down monitor...");
         eprintln!("[SIGNAL] Ctrl+C signal received!");
 
-        // Signal CFRunLoop to stop
-        winshift::stop_hook().expect("Failed to stop hook");
+        if let Err(err) = stop_handle.stop() {
+            eprintln!("Failed to stop hook: {err}");
+        }
 
         eprintln!("[SIGNAL] Stop signal sent, exiting signal handler");
     })?;
 
     // Run the monitor on main thread (required for NSWorkspace and Accessibility API)
-    if let Ok(guard) = hook_ref.read() {
-        if let Some(ref hook) = *guard {
-            if let Err(e) = hook.run() {
-                eprintln!("Error running hook: {e}");
-            }
-        }
-    }
-
-    // When hook.run() exits, clean up
-    println!("Monitor stopped.");
-    if let Ok(mut guard) = hook_clone.write() {
-        guard.take(); // Take ownership to clean up
+    if let Err(e) = hook.run() {
+        eprintln!("Error running hook: {e}");
     }
 
     println!("Monitor stopped.");

--- a/examples/window_only_monitor.rs
+++ b/examples/window_only_monitor.rs
@@ -56,37 +56,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let handler = WindowOnlyHandler::new();
-    let hook = WindowFocusHook::window_only(handler);
-
-    // Set up Ctrl+C handler with proper CFRunLoop termination
-    let hook_ref = Arc::new(RwLock::new(Some(hook)));
-    let hook_clone = hook_ref.clone();
+    let hook = Arc::new(WindowFocusHook::window_only(handler));
+    let stop_handle = hook.clone();
 
     ::ctrlc::set_handler(move || {
         println!("\nShutting down window-only monitor...");
         eprintln!("[SIGNAL] Ctrl+C signal received!");
 
-        // Signal CFRunLoop to stop
-        winshift::stop_hook().expect("Failed to stop hook");
+        if let Err(err) = stop_handle.stop() {
+            eprintln!("Failed to stop hook: {err}");
+        }
 
         eprintln!("[SIGNAL] Stop signal sent, exiting signal handler");
     })?;
 
     // Run the monitor on main thread (required for NSWorkspace and Accessibility API)
-    if let Ok(guard) = hook_ref.read() {
-        if let Some(ref hook) = *guard {
-            if let Err(e) = hook.run() {
-                eprintln!("Error running hook: {e}");
-            }
-        }
+    if let Err(e) = hook.run() {
+        eprintln!("Error running hook: {e}");
     }
 
-    // When hook.run() exits, clean up
     println!("Window-only monitor stopped.");
-    if let Ok(mut guard) = hook_clone.write() {
-        guard.take(); // Take ownership to clean up
-    }
-
-    println!("Monitor stopped.");
     Ok(())
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,6 +4,24 @@ use log::{debug, trace};
 
 use crate::error::WinshiftError;
 
+#[cfg(target_os = "linux")]
+use crate::linux::HookStopHandle as PlatformStopHandle;
+#[cfg(target_os = "macos")]
+use crate::macos::HookStopHandle as PlatformStopHandle;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[derive(Clone, Default)]
+struct PlatformStopHandle;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+impl PlatformStopHandle {
+    fn stop(&self) -> Result<(), WinshiftError> {
+        Err(WinshiftError::Platform(
+            "Unsupported platform: stop not implemented".to_string(),
+        ))
+    }
+}
+
 /// Monitoring mode for selective event tracking
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MonitoringMode {
@@ -71,6 +89,7 @@ pub struct WindowHookConfig {
 pub struct WindowFocusHook {
     handler: Arc<RwLock<dyn FocusChangeHandler>>,
     config: WindowHookConfig,
+    stop_handle: PlatformStopHandle,
 }
 
 impl WindowFocusHook {
@@ -81,6 +100,7 @@ impl WindowFocusHook {
         Self {
             handler: Arc::new(RwLock::new(handler)),
             config: WindowHookConfig::default(),
+            stop_handle: PlatformStopHandle::default(),
         }
     }
 
@@ -97,6 +117,7 @@ impl WindowFocusHook {
         Self {
             handler: Arc::new(RwLock::new(handler)),
             config,
+            stop_handle: PlatformStopHandle::default(),
         }
     }
 
@@ -135,13 +156,21 @@ impl WindowFocusHook {
         #[cfg(target_os = "linux")]
         {
             trace!("Running on Linux platform");
-            crate::linux::run_hook_with_config(self.handler.clone(), &self.config)
+            crate::linux::run_hook_with_config(
+                self.handler.clone(),
+                &self.config,
+                self.stop_handle.clone(),
+            )
         }
 
         #[cfg(target_os = "macos")]
         {
             trace!("Running on macOS platform");
-            crate::macos::run_hook_with_config(self.handler.clone(), &self.config)
+            crate::macos::run_hook_with_config(
+                self.handler.clone(),
+                &self.config,
+                self.stop_handle.clone(),
+            )
         }
 
         #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
@@ -155,30 +184,8 @@ impl WindowFocusHook {
     ///
     /// # Errors
     /// Returns `WinshiftError` if platform stop operation fails
-    pub fn stop() -> Result<(), WinshiftError> {
-        debug!("Stopping WindowFocusHook");
-        #[cfg(target_os = "windows")]
-        {
-            trace!("Stopping on Windows platform");
-            crate::windows::stop_hook()
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            trace!("Stopping on Linux platform");
-            crate::linux::stop_hook()
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            trace!("Stopping on macOS platform");
-            crate::macos::stop_hook()
-        }
-
-        #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
-        {
-            error!("Unsupported platform");
-            Err(WinshiftError::Platform("Unsupported platform".to_string()))
-        }
+    pub fn stop(&self) -> Result<(), WinshiftError> {
+        debug!("Stopping WindowFocusHook instance");
+        self.stop_handle.stop()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use log::{debug, error, info, trace, warn};
 pub use env_logger;
 
 #[cfg(target_os = "macos")]
-#[deprecated(note = "Use WindowFocusHook::stop on the hook instance instead")]
+#[allow(deprecated)]
 pub use macos::stop_hook;
 #[cfg(target_os = "macos")]
 pub use macos::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use log::{debug, error, info, trace, warn};
 pub use env_logger;
 
 #[cfg(target_os = "macos")]
+#[deprecated(note = "Use WindowFocusHook::stop on the hook instance instead")]
 pub use macos::stop_hook;
 #[cfg(target_os = "macos")]
 pub use macos::{

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -3,12 +3,11 @@
 //! This implementation uses `static mut` variables which are not thread-safe.
 //! It assumes single-threaded usage on the main thread only.
 //!
-//! TODO: Replace `static mut INTERRUPT_PIPE` with thread-safe alternative
 //! TODO: Consider thread-safe X11 event handling
 
 use std::ffi::CStr;
 use std::os::unix::io::RawFd;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use libc::{c_char, c_int, c_uchar, c_ulong, c_void, close, pipe, read, write, EINTR};
 use libc::{fd_set, select, FD_SET, FD_ZERO};
@@ -18,31 +17,96 @@ use x11::xlib;
 use crate::error::WinshiftError;
 use crate::FocusChangeHandler;
 
-// TODO: Make this thread-safe (e.g. using lazy_static with Mutex)
-static mut INTERRUPT_PIPE: [RawFd; 2] = [-1, -1];
+#[derive(Clone, Default)]
+pub struct HookStopHandle {
+    inner: Arc<HookStopState>,
+}
+
+#[derive(Default)]
+struct HookStopState {
+    write_fd: Mutex<Option<RawFd>>,
+}
+
+impl HookStopHandle {
+    pub(crate) fn register_pipe(&self, write_fd: RawFd) {
+        *self.inner.write_fd.lock().unwrap() = Some(write_fd);
+    }
+
+    pub(crate) fn clear(&self) {
+        *self.inner.write_fd.lock().unwrap() = None;
+    }
+
+    pub fn stop(&self) -> Result<(), WinshiftError> {
+        if let Some(fd) = *self.inner.write_fd.lock().unwrap() {
+            let buf = [0u8; 1];
+            let written = unsafe { write(fd, buf.as_ptr() as *const c_void, 1) };
+            if written == 1 {
+                return Ok(());
+            }
+            return Err(WinshiftError::Stop);
+        }
+        Err(WinshiftError::Stop)
+    }
+}
+
+impl HookStopState {
+    fn new() -> Self {
+        Self {
+            write_fd: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for HookStopState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static GLOBAL_STOP_HANDLE: Mutex<Option<HookStopHandle>> = Mutex::new(None);
+
+fn install_global_stop_handle(handle: &HookStopHandle) {
+    *GLOBAL_STOP_HANDLE.lock().unwrap() = Some(handle.clone());
+}
+
+fn clear_global_stop_handle() {
+    *GLOBAL_STOP_HANDLE.lock().unwrap() = None;
+}
 
 pub(crate) fn run_hook_with_config(
     handler: Arc<RwLock<dyn FocusChangeHandler>>,
     _config: &crate::hook::WindowHookConfig,
+    stop_handle: HookStopHandle,
 ) -> Result<(), WinshiftError> {
-    run_hook(handler)
+    run_hook(handler, stop_handle)
 }
 
-fn run_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), WinshiftError> {
+fn run_hook(
+    handler: Arc<RwLock<dyn FocusChangeHandler>>,
+    stop_handle: HookStopHandle,
+) -> Result<(), WinshiftError> {
     debug!("Starting Linux hook");
     unsafe {
+        let mut interrupt_pipe = [-1; 2];
         // Create the self-pipe
-        if pipe(INTERRUPT_PIPE.as_mut_ptr()) != 0 {
+        if pipe(interrupt_pipe.as_mut_ptr()) != 0 {
             error!("Failed to create interrupt pipe");
             return Err(WinshiftError::Initialization);
         }
         trace!("Interrupt pipe created");
 
+        let read_fd = interrupt_pipe[0];
+        let write_fd = interrupt_pipe[1];
+        stop_handle.register_pipe(write_fd);
+        install_global_stop_handle(&stop_handle);
+
         let display = xlib::XOpenDisplay(std::ptr::null());
         if display.is_null() {
             error!("Failed to open X11 display");
-            close(INTERRUPT_PIPE[0]);
-            close(INTERRUPT_PIPE[1]);
+            close(read_fd);
+            close(write_fd);
+            stop_handle.clear();
+            clear_global_stop_handle();
             return Err(WinshiftError::Initialization);
         }
         debug!("X11 display opened successfully");
@@ -75,9 +139,9 @@ fn run_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), Winshift
         let mut in_fds: fd_set = std::mem::zeroed();
         FD_ZERO(&mut in_fds);
         FD_SET(x11_fd, &mut in_fds);
-        FD_SET(INTERRUPT_PIPE[0], &mut in_fds);
+        FD_SET(read_fd, &mut in_fds);
 
-        let max_fd = x11_fd.max(INTERRUPT_PIPE[0]) + 1;
+        let max_fd = x11_fd.max(read_fd) + 1;
 
         loop {
             trace!("Waiting for X11 events or interrupt signal");
@@ -91,10 +155,10 @@ fn run_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), Winshift
                 std::ptr::null_mut(),
             ) > 0
             {
-                if libc::FD_ISSET(INTERRUPT_PIPE[0], &read_fds) {
+                if libc::FD_ISSET(read_fd, &read_fds) {
                     debug!("Received interrupt signal");
                     let mut buf = [0u8; 1];
-                    read(INTERRUPT_PIPE[0], buf.as_mut_ptr() as *mut c_void, 1);
+                    read(read_fd, buf.as_mut_ptr() as *mut c_void, 1);
                     break;
                 }
 
@@ -196,27 +260,26 @@ fn run_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), Winshift
         debug!("X11 display closed");
 
         // Close the self-pipe
-        close(INTERRUPT_PIPE[0]);
-        close(INTERRUPT_PIPE[1]);
+        close(read_fd);
+        close(write_fd);
         trace!("Interrupt pipe closed");
     }
+
+    stop_handle.clear();
+    clear_global_stop_handle();
 
     debug!("Linux hook stopped");
     Ok(())
 }
 
+#[deprecated(note = "Use WindowFocusHook::stop instead")]
 pub fn stop_hook() -> Result<(), WinshiftError> {
-    debug!("Attempting to stop Linux hook");
-    unsafe {
-        // Send interrupt signal through the pipe
-        let buf = [0u8; 1];
-        if write(INTERRUPT_PIPE[1], buf.as_ptr() as *const c_void, 1) != 1 {
-            error!("Failed to send interrupt signal");
-            return Err(WinshiftError::Stop);
-        }
+    debug!("Attempting to stop Linux hook via global handle");
+    if let Some(handle) = GLOBAL_STOP_HANDLE.lock().unwrap().clone() {
+        handle.stop()
+    } else {
+        Err(WinshiftError::Stop)
     }
-    debug!("Linux hook stop signal sent");
-    Ok(())
 }
 
 unsafe fn get_active_window(

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -272,7 +272,7 @@ fn run_hook(
     Ok(())
 }
 
-#[deprecated(note = "Use WindowFocusHook::stop instead")]
+#[deprecated(note = "Use instance stop(); stop_hook is a legacy static fallback")]
 pub fn stop_hook() -> Result<(), WinshiftError> {
     debug!("Attempting to stop Linux hook via global handle");
     if let Some(handle) = GLOBAL_STOP_HANDLE.lock().unwrap().clone() {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -4,13 +4,12 @@
 //! It assumes single-threaded usage on the main thread only.
 //!
 //! TODO: Replace `static mut` with thread-safe alternatives (Mutex/RwLock)
-//! TODO: Implement hook-specific stop methods instead of global stop
 
 use std::collections::HashMap;
 use std::ffi;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use core_foundation::base::{CFGetTypeID, CFType, TCFType};
 use core_foundation::runloop::{kCFRunLoopDefaultMode, CFRunLoop};
@@ -31,16 +30,55 @@ static mut CURRENT_RUN_LOOP: Option<CFRunLoop> = None;
 // Controls whether we compute and emit embedded ActiveWindowInfo in callbacks
 static EMBED_ACTIVE_INFO: AtomicBool = AtomicBool::new(false);
 
+#[derive(Clone, Default)]
+pub struct HookStopHandle {
+    inner: Arc<HookStopState>,
+}
+
+#[derive(Default)]
+struct HookStopState {
+    run_loop: Mutex<Option<CFRunLoop>>,
+}
+
+impl HookStopHandle {
+    pub(crate) fn set_run_loop(&self, run_loop: &CFRunLoop) {
+        *self.inner.run_loop.lock().unwrap() = Some(run_loop.clone());
+    }
+
+    pub(crate) fn clear(&self) {
+        *self.inner.run_loop.lock().unwrap() = None;
+    }
+
+    pub fn stop(&self) -> Result<(), WinshiftError> {
+        if let Some(run_loop) = self.inner.run_loop.lock().unwrap().clone() {
+            run_loop.stop();
+            return Ok(());
+        }
+        Err(WinshiftError::Stop)
+    }
+}
+
+static GLOBAL_STOP_HANDLE: Mutex<Option<HookStopHandle>> = Mutex::new(None);
+
+fn install_global_stop_handle(handle: &HookStopHandle) {
+    *GLOBAL_STOP_HANDLE.lock().unwrap() = Some(handle.clone());
+}
+
+fn clear_global_stop_handle() {
+    *GLOBAL_STOP_HANDLE.lock().unwrap() = None;
+}
+
 pub(crate) fn run_hook_with_config(
     handler: Arc<RwLock<dyn FocusChangeHandler>>,
     config: &crate::hook::WindowHookConfig,
+    stop_handle: HookStopHandle,
 ) -> Result<(), WinshiftError> {
     trace!(
         "Starting macOS hook with monitoring mode: {:?}",
         config.monitoring_mode
     );
     EMBED_ACTIVE_INFO.store(config.embed_active_info, Ordering::Relaxed);
-    run_accessibility_hook_with_mode(handler, config.monitoring_mode)
+    run_accessibility_hook_with_mode(handler, config.monitoring_mode, stop_handle)
 }
 
 // ===== Active window info (CG + AX comparison) =====
@@ -512,18 +550,20 @@ struct ObserverInfo {
 fn run_accessibility_hook_with_mode(
     handler: Arc<RwLock<dyn FocusChangeHandler>>,
     mode: crate::hook::MonitoringMode,
+    stop_handle: HookStopHandle,
 ) -> Result<(), WinshiftError> {
     use crate::hook::MonitoringMode;
 
     match mode {
-        MonitoringMode::Combined => run_accessibility_hook(handler),
-        MonitoringMode::AppOnly => run_app_only_hook(handler),
-        MonitoringMode::WindowOnly => run_window_only_hook(handler),
+        MonitoringMode::Combined => run_accessibility_hook(handler, stop_handle),
+        MonitoringMode::AppOnly => run_app_only_hook(handler, stop_handle),
+        MonitoringMode::WindowOnly => run_window_only_hook(handler, stop_handle),
     }
 }
 
 fn run_accessibility_hook(
     handler: Arc<RwLock<dyn FocusChangeHandler>>,
+    stop_handle: HookStopHandle,
 ) -> Result<(), WinshiftError> {
     use accessibility_sys::{
         kAXFocusedWindowChangedNotification, AXIsProcessTrusted, AXObserverAddNotification,
@@ -858,7 +898,7 @@ fn run_accessibility_hook(
         setup_nsworkspace_notifications(handler_ptr)?;
 
         info!("Event-driven NSWorkspace monitoring active");
-        run_cfrunloop();
+        run_cfrunloop(&stop_handle);
 
         if let Some(observers) = (&raw mut OBSERVERS).as_mut().unwrap() {
             let run_loop = CFRunLoop::get_current();
@@ -877,7 +917,10 @@ fn run_accessibility_hook(
     Ok(())
 }
 
-fn run_app_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), WinshiftError> {
+fn run_app_only_hook(
+    handler: Arc<RwLock<dyn FocusChangeHandler>>,
+    stop_handle: HookStopHandle,
+) -> Result<(), WinshiftError> {
     use core_foundation::base::TCFType;
     use core_foundation::string::CFString;
     use objc2::declare::ClassDecl;
@@ -1036,7 +1079,7 @@ fn run_app_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(),
         }
 
         setup_nsworkspace_notifications_only(handler_ptr)?;
-        run_cfrunloop();
+        run_cfrunloop(&stop_handle);
         let _ = Box::from_raw(handler_ptr);
         trace!("App-only hook stopped");
     }
@@ -1044,7 +1087,10 @@ fn run_app_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(),
     Ok(())
 }
 
-fn run_window_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<(), WinshiftError> {
+fn run_window_only_hook(
+    handler: Arc<RwLock<dyn FocusChangeHandler>>,
+    stop_handle: HookStopHandle,
+) -> Result<(), WinshiftError> {
     use accessibility_sys::{
         kAXFocusedWindowChangedNotification, AXIsProcessTrusted, AXObserverAddNotification,
         AXObserverCallback, AXObserverCreate, AXObserverGetRunLoopSource,
@@ -1136,7 +1182,7 @@ fn run_window_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<
             }
         }
 
-        run_cfrunloop();
+        run_cfrunloop(&stop_handle);
 
         let run_loop = CFRunLoop::get_current();
         run_loop.remove_source(&observer_info.run_loop_source, kCFRunLoopDefaultMode);
@@ -1147,13 +1193,15 @@ fn run_window_only_hook(handler: Arc<RwLock<dyn FocusChangeHandler>>) -> Result<
     Ok(())
 }
 
-fn run_cfrunloop() {
+fn run_cfrunloop(stop_handle: &HookStopHandle) {
     info!("Getting current CFRunLoop");
 
     let run_loop = CFRunLoop::get_current();
     unsafe {
         CURRENT_RUN_LOOP = Some(run_loop.clone());
     }
+    stop_handle.set_run_loop(&run_loop);
+    install_global_stop_handle(stop_handle);
 
     info!("CFRunLoop starting");
     CFRunLoop::run_current();
@@ -1162,6 +1210,8 @@ fn run_cfrunloop() {
     unsafe {
         CURRENT_RUN_LOOP = None;
     }
+    stop_handle.clear();
+    clear_global_stop_handle();
 }
 
 fn get_app_name_by_pid(pid: i32) -> Option<String> {
@@ -1263,20 +1313,13 @@ fn get_current_window_title() -> Option<String> {
     }
 }
 
+#[deprecated(note = "Use WindowFocusHook::stop instead")]
 pub fn stop_hook() -> Result<(), WinshiftError> {
-    info!("=== STOP_HOOK CALLED ====");
-    trace!("Stopping macOS hook");
-
-    unsafe {
-        if let Some(ref run_loop) = CURRENT_RUN_LOOP {
-            info!("Found CFRunLoop, calling stop()...");
-            run_loop.stop();
-            info!("CFRunLoop::stop() called successfully");
-        } else {
-            warn!("No current CFRunLoop stored termination");
-        }
+    info!("macOS stop_hook invoked");
+    if let Some(handle) = GLOBAL_STOP_HANDLE.lock().unwrap().clone() {
+        handle.stop()
+    } else {
+        warn!("No active hook instance available to stop");
+        Err(WinshiftError::Stop)
     }
-
-    info!("=== STOP_HOOK COMPLETED ====");
-    Ok(())
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1313,7 +1313,7 @@ fn get_current_window_title() -> Option<String> {
     }
 }
 
-#[deprecated(note = "Use WindowFocusHook::stop instead")]
+#[deprecated(note = "Use instance stop(); stop_hook is a legacy static fallback")]
 pub fn stop_hook() -> Result<(), WinshiftError> {
     info!("macOS stop_hook invoked");
     if let Some(handle) = GLOBAL_STOP_HANDLE.lock().unwrap().clone() {


### PR DESCRIPTION
Issue: https://github.com/efJerryYang/winshift-rs/issues/5

This should close #5. The `WindowFocusHook::stop` won't compile after this.