### PR TITLE
MacOS memory fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log4rs = "1.3.0"
 env_logger = "0.11.8"
 
 [dev-dependencies]
+clap = { version = "4.5.39", features = ["derive"] }
 sysinfo = "0.37.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ ctrlc = "3.4.5"
 log4rs = "1.3.0"
 env_logger = "0.11.8"
 
+[dev-dependencies]
+sysinfo = "0.37.2"
+
 [features]
 default = []
 cargo-clippy = []

--- a/examples/macos_memory_diagnostics.rs
+++ b/examples/macos_memory_diagnostics.rs
@@ -1,0 +1,342 @@
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("macos_memory_diagnostics is intended for macOS only");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "macos")]
+mod macos_repro {
+    use clap::{Parser, ValueEnum};
+    use std::hint::black_box;
+    use std::process;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+    use winshift::{
+        ActiveWindowInfo, FocusChangeHandler, MonitoringMode, WindowFocusHook, WindowHookConfig,
+        get_active_window_info,
+    };
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+    enum Mode {
+        HookCycle,
+        QueryLoop,
+    }
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+    enum Monitor {
+        Combined,
+        AppOnly,
+        WindowOnly,
+    }
+
+    impl Monitor {
+        fn into_winshift(self) -> MonitoringMode {
+            match self {
+                Self::Combined => MonitoringMode::Combined,
+                Self::AppOnly => MonitoringMode::AppOnly,
+                Self::WindowOnly => MonitoringMode::WindowOnly,
+            }
+        }
+    }
+
+    #[derive(Parser, Debug)]
+    #[command(name = "macos_memory_diagnostics")]
+    #[command(about = "Manual macOS memory regression diagnostics for winshift")]
+    struct Args {
+        #[arg(long, value_enum, default_value_t = Mode::HookCycle)]
+        mode: Mode,
+
+        #[arg(long, default_value_t = 200)]
+        iterations: u64,
+
+        #[arg(long, default_value_t = 10)]
+        sample_every: u64,
+
+        #[arg(long, value_enum, default_value_t = Monitor::Combined)]
+        monitor: Monitor,
+
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+        embed_active_info: bool,
+
+        #[arg(long, default_value_t = 250)]
+        hook_run_ms: u64,
+
+        #[arg(long, default_value_t = 50)]
+        cooldown_ms: u64,
+
+        #[arg(long, default_value_t = 10)]
+        query_sleep_ms: u64,
+    }
+
+    #[derive(Default)]
+    struct CallbackStats {
+        app_changes: AtomicU64,
+        window_changes: AtomicU64,
+        app_info_changes: AtomicU64,
+        window_info_changes: AtomicU64,
+    }
+
+    struct CountingHandler {
+        stats: Arc<CallbackStats>,
+    }
+
+    impl CountingHandler {
+        fn new(stats: Arc<CallbackStats>) -> Self {
+            Self { stats }
+        }
+    }
+
+    impl FocusChangeHandler for CountingHandler {
+        fn on_app_change(&self, _pid: i32, _app_name: String) {
+            self.stats.app_changes.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn on_window_change(&self, _window_title: String) {
+            self.stats.window_changes.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn on_app_change_info(&self, _info: ActiveWindowInfo) {
+            self.stats.app_info_changes.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn on_window_change_info(&self, _info: ActiveWindowInfo) {
+            self.stats
+                .window_info_changes
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    struct RunStats {
+        started_at: Instant,
+        baseline_rss_bytes: Option<u64>,
+        query_ok: u64,
+        query_err: u64,
+        hook_ok: u64,
+        hook_err: u64,
+        stop_attempts: u64,
+        stop_retries: u64,
+    }
+
+    impl RunStats {
+        fn new() -> Self {
+            Self {
+                started_at: Instant::now(),
+                baseline_rss_bytes: current_rss_bytes(),
+                query_ok: 0,
+                query_err: 0,
+                hook_ok: 0,
+                hook_err: 0,
+                stop_attempts: 0,
+                stop_retries: 0,
+            }
+        }
+    }
+
+    struct StopReport {
+        attempts: u64,
+        retries: u64,
+    }
+
+    pub fn main() {
+        let args = Args::parse();
+        println!(
+            "starting mode={:?} pid={} monitor={:?} embed_active_info={} iterations={} sample_every={}",
+            args.mode,
+            process::id(),
+            args.monitor,
+            args.embed_active_info,
+            args.iterations,
+            args.sample_every
+        );
+        println!(
+            "tip: compare before/after fix with the same command and watch rss_mb / rss_delta_mb"
+        );
+
+        let stats = Arc::new(CallbackStats::default());
+        let mut run_stats = RunStats::new();
+
+        match args.mode {
+            Mode::HookCycle => run_hook_cycles(&args, &stats, &mut run_stats),
+            Mode::QueryLoop => run_query_loop(&args, &stats, &mut run_stats),
+        }
+    }
+
+    fn run_hook_cycles(args: &Args, stats: &Arc<CallbackStats>, run_stats: &mut RunStats) {
+        let config = WindowHookConfig {
+            monitoring_mode: args.monitor.into_winshift(),
+            embed_active_info: args.embed_active_info,
+        };
+        let mut cycle = 0_u64;
+
+        while keep_running(cycle, args.iterations) {
+            cycle += 1;
+            let hook = Arc::new(WindowFocusHook::with_config(
+                CountingHandler::new(Arc::clone(stats)),
+                config.clone(),
+            ));
+            let run_done = Arc::new(AtomicBool::new(false));
+            let stopper = spawn_stopper(
+                Arc::clone(&hook),
+                Arc::clone(&run_done),
+                Duration::from_millis(args.hook_run_ms),
+            );
+
+            let run_result = hook.run();
+            run_done.store(true, Ordering::Relaxed);
+            let stop_report = stopper.join().unwrap_or(StopReport {
+                attempts: 0,
+                retries: 0,
+            });
+
+            run_stats.stop_attempts = run_stats.stop_attempts.saturating_add(stop_report.attempts);
+            run_stats.stop_retries = run_stats.stop_retries.saturating_add(stop_report.retries);
+
+            match run_result {
+                Ok(()) => run_stats.hook_ok = run_stats.hook_ok.saturating_add(1),
+                Err(err) => {
+                    run_stats.hook_err = run_stats.hook_err.saturating_add(1);
+                    eprintln!("hook_cycle_error cycle={} error={}", cycle, err);
+                    print_sample("hook-cycle", cycle, stats, run_stats);
+                    break;
+                }
+            }
+
+            if should_sample(cycle, args.sample_every) {
+                print_sample("hook-cycle", cycle, stats, run_stats);
+            }
+
+            if args.cooldown_ms > 0 {
+                thread::sleep(Duration::from_millis(args.cooldown_ms));
+            }
+        }
+
+        print_sample("hook-cycle", cycle, stats, run_stats);
+    }
+
+    fn run_query_loop(args: &Args, stats: &Arc<CallbackStats>, run_stats: &mut RunStats) {
+        let mut iteration = 0_u64;
+
+        while keep_running(iteration, args.iterations) {
+            iteration += 1;
+            match get_active_window_info() {
+                Ok(info) => {
+                    run_stats.query_ok = run_stats.query_ok.saturating_add(1);
+                    black_box((
+                        info.process_id,
+                        info.window_id,
+                        info.title.len(),
+                        info.app_name.len(),
+                    ));
+                }
+                Err(err) => {
+                    run_stats.query_err = run_stats.query_err.saturating_add(1);
+                    if should_sample(iteration, args.sample_every) {
+                        eprintln!("query_loop_error iteration={} error={}", iteration, err);
+                    }
+                }
+            }
+
+            if should_sample(iteration, args.sample_every) {
+                print_sample("query-loop", iteration, stats, run_stats);
+            }
+
+            if args.query_sleep_ms > 0 {
+                thread::sleep(Duration::from_millis(args.query_sleep_ms));
+            }
+        }
+
+        print_sample("query-loop", iteration, stats, run_stats);
+    }
+
+    fn spawn_stopper(
+        hook: Arc<WindowFocusHook>,
+        run_done: Arc<AtomicBool>,
+        run_for: Duration,
+    ) -> thread::JoinHandle<StopReport> {
+        thread::spawn(move || {
+            thread::sleep(run_for);
+            let mut attempts = 0_u64;
+            let mut retries = 0_u64;
+
+            loop {
+                if run_done.load(Ordering::Relaxed) {
+                    return StopReport { attempts, retries };
+                }
+
+                attempts = attempts.saturating_add(1);
+                match hook.stop() {
+                    Ok(()) => return StopReport { attempts, retries },
+                    Err(_) => {
+                        retries = retries.saturating_add(1);
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                }
+            }
+        })
+    }
+
+    fn keep_running(iteration: u64, limit: u64) -> bool {
+        limit == 0 || iteration < limit
+    }
+
+    fn should_sample(iteration: u64, sample_every: u64) -> bool {
+        sample_every > 0 && iteration % sample_every == 0
+    }
+
+    fn current_rss_bytes() -> Option<u64> {
+        let pid = Pid::from(process::id() as usize);
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_memory(),
+        );
+        system.process(pid).map(|process| process.memory())
+    }
+
+    fn print_sample(
+        label: &str,
+        iteration: u64,
+        stats: &Arc<CallbackStats>,
+        run_stats: &RunStats,
+    ) {
+        let rss_bytes = current_rss_bytes();
+        let rss_mb = rss_bytes.map(bytes_to_mb).unwrap_or(-1.0);
+        let rss_delta_mb = match (run_stats.baseline_rss_bytes, rss_bytes) {
+            (Some(base), Some(now)) => bytes_to_mb(now.saturating_sub(base)),
+            _ => -1.0,
+        };
+        let elapsed = run_stats.started_at.elapsed().as_secs_f64();
+
+        println!(
+            "sample label={} iteration={} elapsed_s={:.3} rss_mb={:.3} rss_delta_mb={:.3} query_ok={} query_err={} hook_ok={} hook_err={} stop_attempts={} stop_retries={} app_changes={} window_changes={} app_info={} window_info={}",
+            label,
+            iteration,
+            elapsed,
+            rss_mb,
+            rss_delta_mb,
+            run_stats.query_ok,
+            run_stats.query_err,
+            run_stats.hook_ok,
+            run_stats.hook_err,
+            run_stats.stop_attempts,
+            run_stats.stop_retries,
+            stats.app_changes.load(Ordering::Relaxed),
+            stats.window_changes.load(Ordering::Relaxed),
+            stats.app_info_changes.load(Ordering::Relaxed),
+            stats.window_info_changes.load(Ordering::Relaxed),
+        );
+    }
+
+    fn bytes_to_mb(bytes: u64) -> f64 {
+        bytes as f64 / (1024.0 * 1024.0)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_repro::main();
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -16,6 +16,7 @@ use core_foundation::runloop::{kCFRunLoopDefaultMode, CFRunLoop};
 use core_foundation::string::{CFString, CFStringGetTypeID, CFStringRef};
 use log::{debug, error, info, trace, warn};
 use objc2::declare::ClassDecl;
+use objc2::rc::autoreleasepool;
 use objc2::runtime;
 use objc2::runtime::{Object, Sel};
 use objc2::{class, msg_send, sel, sel_impl};
@@ -130,142 +131,151 @@ pub struct ActiveWindowInfo {
 // window's PID/title/bounds, then matching a CoreGraphics window to retrieve
 // its stable window_id. This function does not require inputs.
 pub fn get_active_window_info() -> Result<ActiveWindowInfo, WinshiftError> {
-    // Find frontmost application (PID + name)
-    let (pid, app_name) = unsafe {
-        let workspace_class = class!(NSWorkspace);
-        let workspace: *mut runtime::Object = msg_send![workspace_class, sharedWorkspace];
-        let frontmost_app: *mut runtime::Object = msg_send![workspace, frontmostApplication];
-        if frontmost_app.is_null() {
-            return Err(WinshiftError::MacOS("No frontmost application".into()));
-        }
-        let pid: i32 = msg_send![frontmost_app, processIdentifier];
-        let name = get_app_name_by_pid(pid).unwrap_or_else(|| String::from("Unknown"));
-        (pid, name)
-    };
+    autoreleasepool(|| {
+        // Find frontmost application (PID + name)
+        let (pid, app_name) = unsafe {
+            let workspace_class = class!(NSWorkspace);
+            let workspace: *mut runtime::Object = msg_send![workspace_class, sharedWorkspace];
+            let frontmost_app: *mut runtime::Object = msg_send![workspace, frontmostApplication];
+            if frontmost_app.is_null() {
+                return Err(WinshiftError::MacOS("No frontmost application".into()));
+            }
+            let pid: i32 = msg_send![frontmost_app, processIdentifier];
+            let name = get_app_name_by_pid(pid).unwrap_or_else(|| String::from("Unknown"));
+            (pid, name)
+        };
 
-    // Build a partial ActiveWindowInfo with AX data when available.
-    let mut info = ActiveWindowInfo {
-        title: String::new(),
-        app_name,
-        window_id: INVALID_WINDOW_ID,
-        process_id: pid,
-        bounds: WindowBounds {
-            x: 0.0,
-            y: 0.0,
-            width: 0.0,
-            height: 0.0,
-        },
-        proc_path: get_proc_path_by_pid(pid).unwrap_or_default(),
-    };
+        // Build a partial ActiveWindowInfo with AX data when available.
+        let mut info = ActiveWindowInfo {
+            title: String::new(),
+            app_name,
+            window_id: INVALID_WINDOW_ID,
+            process_id: pid,
+            bounds: WindowBounds {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            proc_path: get_proc_path_by_pid(pid).unwrap_or_default(),
+        };
 
-    unsafe {
-        if accessibility_sys::AXIsProcessTrusted() {
-            let app_element = accessibility_sys::AXUIElementCreateApplication(pid);
+        unsafe {
+            if accessibility_sys::AXIsProcessTrusted() {
+                let app_element = accessibility_sys::AXUIElementCreateApplication(pid);
 
-            // Focused window element
-            let mut focused_window: *mut ffi::c_void = ptr::null_mut();
-            let focused_attr =
-                CFString::from_static_string(accessibility_sys::kAXFocusedWindowAttribute);
-            let res = accessibility_sys::AXUIElementCopyAttributeValue(
-                app_element,
-                focused_attr.as_concrete_TypeRef(),
-                std::ptr::from_mut::<*mut ffi::c_void>(&mut focused_window)
-                    .cast::<*const ffi::c_void>(),
-            );
-            if res == 0 && !focused_window.is_null() {
-                // Title
-                let mut title_ptr: *mut ffi::c_void = ptr::null_mut();
-                let title_attr = CFString::from_static_string(accessibility_sys::kAXTitleAttribute);
-                let _ = accessibility_sys::AXUIElementCopyAttributeValue(
-                    focused_window as _,
-                    title_attr.as_concrete_TypeRef(),
-                    std::ptr::from_mut::<*mut ffi::c_void>(&mut title_ptr)
+                let mut focused_window: *mut ffi::c_void = ptr::null_mut();
+                let focused_attr =
+                    CFString::from_static_string(accessibility_sys::kAXFocusedWindowAttribute);
+                let res = accessibility_sys::AXUIElementCopyAttributeValue(
+                    app_element,
+                    focused_attr.as_concrete_TypeRef(),
+                    std::ptr::from_mut::<*mut ffi::c_void>(&mut focused_window)
                         .cast::<*const ffi::c_void>(),
                 );
-                if !title_ptr.is_null() {
-                    let cf_value = CFType::wrap_under_create_rule(title_ptr);
-                    if let Some(s) = cf_value.downcast::<CFString>() {
-                        info.title = s.to_string();
-                    }
-                }
-
-                // Position
-                let mut pos_ptr: *mut ffi::c_void = ptr::null_mut();
-                let pos_attr =
-                    CFString::from_static_string(accessibility_sys::kAXPositionAttribute);
-                let _ = accessibility_sys::AXUIElementCopyAttributeValue(
-                    focused_window as _,
-                    pos_attr.as_concrete_TypeRef(),
-                    std::ptr::from_mut::<*mut ffi::c_void>(&mut pos_ptr)
-                        .cast::<*const ffi::c_void>(),
-                );
-
-                // Size
-                let mut size_ptr: *mut ffi::c_void = ptr::null_mut();
-                let size_attr = CFString::from_static_string(accessibility_sys::kAXSizeAttribute);
-                let _ = accessibility_sys::AXUIElementCopyAttributeValue(
-                    focused_window as _,
-                    size_attr.as_concrete_TypeRef(),
-                    std::ptr::from_mut::<*mut ffi::c_void>(&mut size_ptr)
-                        .cast::<*const ffi::c_void>(),
-                );
-
-                if !pos_ptr.is_null() && !size_ptr.is_null() {
-                    // Extract numeric using AXValueGetValue
-                    #[repr(C)]
-                    struct CGPoint64 {
-                        x: f64,
-                        y: f64,
-                    }
-                    #[repr(C)]
-                    struct CGSize64 {
-                        width: f64,
-                        height: f64,
-                    }
-                    if accessibility_sys::AXValueGetType(pos_ptr as accessibility_sys::AXValueRef)
-                        == accessibility_sys::kAXValueTypeCGPoint
-                        && accessibility_sys::AXValueGetType(
-                            size_ptr as accessibility_sys::AXValueRef,
-                        ) == accessibility_sys::kAXValueTypeCGSize
-                    {
-                        let mut p = CGPoint64 { x: 0.0, y: 0.0 };
-                        let mut s = CGSize64 {
-                            width: 0.0,
-                            height: 0.0,
-                        };
-                        let ok_p = accessibility_sys::AXValueGetValue(
-                            pos_ptr as accessibility_sys::AXValueRef,
-                            accessibility_sys::kAXValueTypeCGPoint,
-                            &mut p as *mut _ as *mut ffi::c_void,
-                        );
-                        let ok_s = accessibility_sys::AXValueGetValue(
-                            size_ptr as accessibility_sys::AXValueRef,
-                            accessibility_sys::kAXValueTypeCGSize,
-                            &mut s as *mut _ as *mut ffi::c_void,
-                        );
-                        if ok_p && ok_s {
-                            info.bounds = WindowBounds {
-                                x: p.x,
-                                y: p.y,
-                                width: s.width,
-                                height: s.height,
-                            };
+                if res == 0 && !focused_window.is_null() {
+                    let mut title_ptr: *mut ffi::c_void = ptr::null_mut();
+                    let title_attr =
+                        CFString::from_static_string(accessibility_sys::kAXTitleAttribute);
+                    let _ = accessibility_sys::AXUIElementCopyAttributeValue(
+                        focused_window as _,
+                        title_attr.as_concrete_TypeRef(),
+                        std::ptr::from_mut::<*mut ffi::c_void>(&mut title_ptr)
+                            .cast::<*const ffi::c_void>(),
+                    );
+                    if !title_ptr.is_null() {
+                        let cf_value = CFType::wrap_under_create_rule(title_ptr);
+                        if let Some(s) = cf_value.downcast::<CFString>() {
+                            info.title = s.to_string();
                         }
                     }
+
+                    let mut pos_ptr: *mut ffi::c_void = ptr::null_mut();
+                    let pos_attr =
+                        CFString::from_static_string(accessibility_sys::kAXPositionAttribute);
+                    let _ = accessibility_sys::AXUIElementCopyAttributeValue(
+                        focused_window as _,
+                        pos_attr.as_concrete_TypeRef(),
+                        std::ptr::from_mut::<*mut ffi::c_void>(&mut pos_ptr)
+                            .cast::<*const ffi::c_void>(),
+                    );
+
+                    let mut size_ptr: *mut ffi::c_void = ptr::null_mut();
+                    let size_attr =
+                        CFString::from_static_string(accessibility_sys::kAXSizeAttribute);
+                    let _ = accessibility_sys::AXUIElementCopyAttributeValue(
+                        focused_window as _,
+                        size_attr.as_concrete_TypeRef(),
+                        std::ptr::from_mut::<*mut ffi::c_void>(&mut size_ptr)
+                            .cast::<*const ffi::c_void>(),
+                    );
+
+                    if !pos_ptr.is_null() && !size_ptr.is_null() {
+                        #[repr(C)]
+                        struct CGPoint64 {
+                            x: f64,
+                            y: f64,
+                        }
+                        #[repr(C)]
+                        struct CGSize64 {
+                            width: f64,
+                            height: f64,
+                        }
+                        if accessibility_sys::AXValueGetType(
+                            pos_ptr as accessibility_sys::AXValueRef,
+                        ) == accessibility_sys::kAXValueTypeCGPoint
+                            && accessibility_sys::AXValueGetType(
+                                size_ptr as accessibility_sys::AXValueRef,
+                            ) == accessibility_sys::kAXValueTypeCGSize
+                        {
+                            let mut p = CGPoint64 { x: 0.0, y: 0.0 };
+                            let mut s = CGSize64 {
+                                width: 0.0,
+                                height: 0.0,
+                            };
+                            let ok_p = accessibility_sys::AXValueGetValue(
+                                pos_ptr as accessibility_sys::AXValueRef,
+                                accessibility_sys::kAXValueTypeCGPoint,
+                                &mut p as *mut _ as *mut ffi::c_void,
+                            );
+                            let ok_s = accessibility_sys::AXValueGetValue(
+                                size_ptr as accessibility_sys::AXValueRef,
+                                accessibility_sys::kAXValueTypeCGSize,
+                                &mut s as *mut _ as *mut ffi::c_void,
+                            );
+                            if ok_p && ok_s {
+                                info.bounds = WindowBounds {
+                                    x: p.x,
+                                    y: p.y,
+                                    width: s.width,
+                                    height: s.height,
+                                };
+                            }
+                        }
+                    }
+
+                    if !pos_ptr.is_null() {
+                        CFRelease(pos_ptr);
+                    }
+                    if !size_ptr.is_null() {
+                        CFRelease(size_ptr);
+                    }
+                    CFRelease(focused_window);
                 }
+                CFRelease(app_element as *const ffi::c_void);
             }
         }
-    }
-    // Now match via CoreGraphics enumeration; by default, don't check title/bounds.
-    match_active_window(
-        &mut info,
-        MatchOptions {
-            match_title: false,
-            match_bounds: false,
-            bounds_tolerance: 1.0,
-        },
-    )?;
-    Ok(info)
+
+        match_active_window(
+            &mut info,
+            MatchOptions {
+                match_title: false,
+                match_bounds: false,
+                bounds_tolerance: 1.0,
+            },
+        )?;
+        Ok(info)
+    })
 }
 
 // Lazy field accessors for CG window dictionaries

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -18,7 +18,7 @@ use log::{debug, error, info, trace, warn};
 use objc2::declare::ClassDecl;
 use objc2::rc::autoreleasepool;
 use objc2::runtime;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{Class, Object, Sel};
 use objc2::{class, msg_send, sel, sel_impl};
 
 use crate::error::WinshiftError;
@@ -555,6 +555,9 @@ unsafe extern "C" fn window_focus_callback(
 
 struct ObserverInfo {
     run_loop_source: core_foundation::runloop::CFRunLoopSource,
+    observer: accessibility_sys::AXObserverRef,
+    app_element: accessibility_sys::AXUIElementRef,
+    handler_ptr: *mut Arc<RwLock<dyn FocusChangeHandler>>,
 }
 
 fn run_accessibility_hook_with_mode(
@@ -578,6 +581,7 @@ fn run_accessibility_hook(
     use accessibility_sys::{
         kAXFocusedWindowChangedNotification, AXIsProcessTrusted, AXObserverAddNotification,
         AXObserverCallback, AXObserverCreate, AXObserverGetRunLoopSource,
+        AXObserverRemoveNotification,
         AXUIElementCreateApplication,
     };
 
@@ -597,6 +601,28 @@ fn run_accessibility_hook(
     static mut OBSERVERS: Option<HashMap<i32, ObserverInfo>> = None;
     unsafe {
         OBSERVERS = Some(HashMap::new());
+    }
+    static mut WINDOW_MONITOR_OBSERVER: *mut Object = ptr::null_mut();
+
+    unsafe fn cleanup_observer_info(pid: i32, observer_info: ObserverInfo) {
+        let window_notification = CFString::from_static_string(kAXFocusedWindowChangedNotification);
+        let run_loop = CFRunLoop::get_current();
+        run_loop.remove_source(&observer_info.run_loop_source, kCFRunLoopDefaultMode);
+
+        let result = AXObserverRemoveNotification(
+            observer_info.observer,
+            observer_info.app_element,
+            window_notification.as_concrete_TypeRef(),
+        );
+        trace!(
+            "AXObserverRemoveNotification result for PID {}: {}",
+            pid,
+            result
+        );
+
+        let _ = Box::from_raw(observer_info.handler_ptr);
+        CFRelease(observer_info.app_element as *const ffi::c_void);
+        CFRelease(observer_info.observer as *const ffi::c_void);
     }
 
     unsafe fn create_observer_for_app(
@@ -643,6 +669,8 @@ fn run_accessibility_hook(
                 error_string(result)
             );
             let _ = Box::from_raw(handler_ptr);
+            CFRelease(app_element as *const ffi::c_void);
+            CFRelease(observer as *const ffi::c_void);
             return Err(WinshiftError::Platform(format!(
                 "Failed to add notification for PID {}: {} ({})",
                 pid,
@@ -663,6 +691,9 @@ fn run_accessibility_hook(
         );
         Ok(ObserverInfo {
             run_loop_source: cf_source,
+            observer,
+            app_element,
+            handler_ptr,
         })
     }
 
@@ -674,11 +705,6 @@ fn run_accessibility_hook(
         trace!("Setting up NSWorkspace notifications");
 
         GLOBAL_HANDLER = Some((*handler_ptr).clone());
-
-        let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("WindowMonitorObserver", superclass).ok_or_else(|| {
-            WinshiftError::Platform("Failed to create observer class".to_string())
-        })?;
 
         extern "C" fn application_did_activate(
             this: &Object,
@@ -754,20 +780,12 @@ fn run_accessibility_hook(
                                     match create_observer_for_app(pid, handler) {
                                         Ok(observer_info) => {
                                             trace!("Observer created successfully, cleaning up old observers...");
-                                            let run_loop = CFRunLoop::get_current();
                                             for (old_pid, old_observer_info) in observers.drain() {
                                                 trace!(
-                                                    "Removing CFRunLoop source for old PID: {}",
+                                                    "Cleaning up observer for old PID: {}",
                                                     old_pid
                                                 );
-                                                run_loop.remove_source(
-                                                    &old_observer_info.run_loop_source,
-                                                    kCFRunLoopDefaultMode,
-                                                );
-                                                trace!(
-                                                    "Cleaned up observer for old PID: {}",
-                                                    old_pid
-                                                );
+                                                cleanup_observer_info(old_pid, old_observer_info);
                                             }
 
                                             trace!("Inserting new observer for PID {}...", pid);
@@ -833,13 +851,23 @@ fn run_accessibility_hook(
             }
         }
 
-        decl.add_method(
-            sel!(applicationDidActivate:),
-            application_did_activate as extern "C" fn(&Object, Sel, *mut Object),
-        );
-
-        let observer_class = decl.register();
-        trace!("Created WindowMonitorObserver class");
+        let observer_class = if let Some(existing) = Class::get("WindowMonitorObserver") {
+            trace!("Reusing existing WindowMonitorObserver class");
+            existing
+        } else {
+            let superclass = class!(NSObject);
+            let mut decl =
+                ClassDecl::new("WindowMonitorObserver", superclass).ok_or_else(|| {
+                    WinshiftError::Platform("Failed to create observer class".to_string())
+                })?;
+            decl.add_method(
+                sel!(applicationDidActivate:),
+                application_did_activate as extern "C" fn(&Object, Sel, *mut Object),
+            );
+            let observer_class = decl.register();
+            trace!("Created WindowMonitorObserver class");
+            observer_class
+        };
 
         let observer_instance: *mut Object = msg_send![observer_class, alloc];
         let observer_instance: *mut Object = msg_send![observer_instance, init];
@@ -847,6 +875,12 @@ fn run_accessibility_hook(
         let workspace_class = class!(NSWorkspace);
         let workspace: *mut Object = msg_send![workspace_class, sharedWorkspace];
         let notification_center: *mut Object = msg_send![workspace, notificationCenter];
+
+        if !WINDOW_MONITOR_OBSERVER.is_null() {
+            let _: () = msg_send![notification_center, removeObserver: WINDOW_MONITOR_OBSERVER];
+            let _: () = msg_send![WINDOW_MONITOR_OBSERVER, release];
+            WINDOW_MONITOR_OBSERVER = ptr::null_mut();
+        }
 
         let notification_name =
             CFString::from_static_string("NSWorkspaceDidActivateApplicationNotification");
@@ -857,6 +891,7 @@ fn run_accessibility_hook(
             name: notification_name.as_concrete_TypeRef()
             object: ptr::null_mut::<Object>()
         ];
+        WINDOW_MONITOR_OBSERVER = observer_instance;
 
         info!("Successfully registered for NSWorkspaceDidActivateApplicationNotification");
         Ok(())
@@ -911,15 +946,23 @@ fn run_accessibility_hook(
         run_cfrunloop(&stop_handle);
 
         if let Some(observers) = (&raw mut OBSERVERS).as_mut().unwrap() {
-            let run_loop = CFRunLoop::get_current();
             for (pid, observer_info) in observers.drain() {
                 trace!("Cleaning up observer for PID: {}", pid);
-                run_loop.remove_source(&observer_info.run_loop_source, kCFRunLoopDefaultMode);
-                trace!("Removed CFRunLoop source for PID: {}", pid);
+                cleanup_observer_info(pid, observer_info);
             }
         }
 
+        let workspace_class = class!(NSWorkspace);
+        let workspace: *mut Object = msg_send![workspace_class, sharedWorkspace];
+        let notification_center: *mut Object = msg_send![workspace, notificationCenter];
+        if !WINDOW_MONITOR_OBSERVER.is_null() {
+            let _: () = msg_send![notification_center, removeObserver: WINDOW_MONITOR_OBSERVER];
+            let _: () = msg_send![WINDOW_MONITOR_OBSERVER, release];
+            WINDOW_MONITOR_OBSERVER = ptr::null_mut();
+        }
+
         CURRENT_RUN_LOOP = None;
+        GLOBAL_HANDLER = None;
         let _ = Box::from_raw(handler_ptr);
         trace!("Accessibility hook stopped");
     }
@@ -949,17 +992,13 @@ fn run_app_only_hook(
     info!("Accessibility permissions verified");
 
     static mut GLOBAL_HANDLER: Option<Arc<RwLock<dyn FocusChangeHandler>>> = None;
+    static mut APP_ONLY_OBSERVER: *mut Object = ptr::null_mut();
     unsafe fn setup_nsworkspace_notifications_only(
         handler_ptr: *mut Arc<RwLock<dyn FocusChangeHandler>>,
     ) -> Result<(), WinshiftError> {
         trace!("Setting up NSWorkspace notifications (app-only mode)");
 
         GLOBAL_HANDLER = Some((*handler_ptr).clone());
-
-        let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("AppOnlyObserver", superclass).ok_or_else(|| {
-            WinshiftError::Platform("Failed to create observer class".to_string())
-        })?;
 
         extern "C" fn application_did_activate(
             this: &Object,
@@ -1029,18 +1068,32 @@ fn run_app_only_hook(
             }
         }
 
-        decl.add_method(
-            sel!(applicationDidActivate:),
-            application_did_activate as extern "C" fn(&Object, Sel, *mut Object),
-        );
-
-        let observer_class = decl.register();
+        let observer_class = if let Some(existing) = Class::get("AppOnlyObserver") {
+            trace!("Reusing existing AppOnlyObserver class");
+            existing
+        } else {
+            let superclass = class!(NSObject);
+            let mut decl = ClassDecl::new("AppOnlyObserver", superclass).ok_or_else(|| {
+                WinshiftError::Platform("Failed to create observer class".to_string())
+            })?;
+            decl.add_method(
+                sel!(applicationDidActivate:),
+                application_did_activate as extern "C" fn(&Object, Sel, *mut Object),
+            );
+            decl.register()
+        };
         let observer_instance: *mut Object = msg_send![observer_class, alloc];
         let observer_instance: *mut Object = msg_send![observer_instance, init];
 
         let workspace_class = class!(NSWorkspace);
         let workspace: *mut Object = msg_send![workspace_class, sharedWorkspace];
         let notification_center: *mut Object = msg_send![workspace, notificationCenter];
+
+        if !APP_ONLY_OBSERVER.is_null() {
+            let _: () = msg_send![notification_center, removeObserver: APP_ONLY_OBSERVER];
+            let _: () = msg_send![APP_ONLY_OBSERVER, release];
+            APP_ONLY_OBSERVER = ptr::null_mut();
+        }
 
         let notification_name =
             CFString::from_static_string("NSWorkspaceDidActivateApplicationNotification");
@@ -1051,6 +1104,7 @@ fn run_app_only_hook(
             name: notification_name.as_concrete_TypeRef()
             object: ptr::null_mut::<Object>()
         ];
+        APP_ONLY_OBSERVER = observer_instance;
 
         info!("App-only monitoring active - no window observers created");
         Ok(())
@@ -1090,6 +1144,16 @@ fn run_app_only_hook(
 
         setup_nsworkspace_notifications_only(handler_ptr)?;
         run_cfrunloop(&stop_handle);
+
+        let workspace_class = class!(NSWorkspace);
+        let workspace: *mut Object = msg_send![workspace_class, sharedWorkspace];
+        let notification_center: *mut Object = msg_send![workspace, notificationCenter];
+        if !APP_ONLY_OBSERVER.is_null() {
+            let _: () = msg_send![notification_center, removeObserver: APP_ONLY_OBSERVER];
+            let _: () = msg_send![APP_ONLY_OBSERVER, release];
+            APP_ONLY_OBSERVER = ptr::null_mut();
+        }
+        GLOBAL_HANDLER = None;
         let _ = Box::from_raw(handler_ptr);
         trace!("App-only hook stopped");
     }
@@ -1104,6 +1168,7 @@ fn run_window_only_hook(
     use accessibility_sys::{
         kAXFocusedWindowChangedNotification, AXIsProcessTrusted, AXObserverAddNotification,
         AXObserverCallback, AXObserverCreate, AXObserverGetRunLoopSource,
+        AXObserverRemoveNotification,
         AXUIElementCreateApplication,
     };
 
@@ -1158,6 +1223,8 @@ fn run_window_only_hook(
 
         if result != 0 {
             let _ = Box::from_raw(handler_ptr);
+            CFRelease(app_element as *const ffi::c_void);
+            CFRelease(observer as *const ffi::c_void);
             return Err(WinshiftError::Platform(format!(
                 "Failed to add notification: {result}"
             )));
@@ -1172,6 +1239,9 @@ fn run_window_only_hook(
         info!("Window-only monitoring active for current app PID: {}", pid);
         Ok(ObserverInfo {
             run_loop_source: cf_source,
+            observer,
+            app_element,
+            handler_ptr,
         })
     }
 
@@ -1196,6 +1266,15 @@ fn run_window_only_hook(
 
         let run_loop = CFRunLoop::get_current();
         run_loop.remove_source(&observer_info.run_loop_source, kCFRunLoopDefaultMode);
+        let window_notification = CFString::from_static_string(kAXFocusedWindowChangedNotification);
+        let _ = AXObserverRemoveNotification(
+            observer_info.observer,
+            observer_info.app_element,
+            window_notification.as_concrete_TypeRef(),
+        );
+        let _ = Box::from_raw(observer_info.handler_ptr);
+        CFRelease(observer_info.app_element as *const ffi::c_void);
+        CFRelease(observer_info.observer as *const ffi::c_void);
         let _ = Box::from_raw(handler_ptr);
         trace!("Window-only hook stopped");
     }

--- a/tests/macos_active_window_query_memory.rs
+++ b/tests/macos_active_window_query_memory.rs
@@ -1,0 +1,57 @@
+#![cfg(target_os = "macos")]
+
+use std::hint::black_box;
+use std::thread;
+use std::time::Duration;
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+use winshift::get_active_window_info;
+
+fn current_rss_bytes() -> Option<u64> {
+    let pid = Pid::from(std::process::id() as usize);
+    let mut system = System::new();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::nothing().with_memory(),
+    );
+    system.process(pid).map(|process| process.memory())
+}
+
+#[test]
+#[ignore = "manual macOS regression test; requires foreground GUI session and Accessibility permission"]
+fn query_loop_memory_stays_bounded() {
+    let baseline = current_rss_bytes().expect("baseline RSS should be available");
+    let iterations = 5_000_u64;
+    let max_delta_bytes = 8_u64 * 1024 * 1024;
+    let mut ok = 0_u64;
+
+    for iteration in 0..iterations {
+        let info = get_active_window_info().unwrap_or_else(|err| {
+            panic!(
+                "get_active_window_info failed at iteration {}: {}",
+                iteration + 1,
+                err
+            )
+        });
+        ok = ok.saturating_add(1);
+        black_box((
+            info.process_id,
+            info.window_id,
+            info.title.len(),
+            info.app_name.len(),
+        ));
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let end = current_rss_bytes().expect("ending RSS should be available");
+    let delta = end.saturating_sub(baseline);
+
+    assert_eq!(ok, iterations, "all query iterations should succeed");
+    assert!(
+        delta <= max_delta_bytes,
+        "query loop RSS delta too large: baseline={} end={} delta={} bytes",
+        baseline,
+        end,
+        delta
+    );
+}


### PR DESCRIPTION
## Summary

This PR fixes two separate macOS memory-growth problems in `winshift-rs`:

1. Query path growth in `get_active_window_info()`
2. Hook lifecycle growth in the macOS observer paths

The history is intentionally split into two commits so each fix can be reviewed independently:

- `1f6c7b8` `fix(macos): release query path objects`
- `07a4097` `fix(macos): clean up hook observer lifecycle`

## What changed

### 1. Query path fix

In `src/macos.rs`, `get_active_window_info()` now:

- runs inside an Objective-C autorelease pool
- releases AX/CoreFoundation objects created during the query path
- stops retaining accessibility objects across repeated calls

This addresses the steady RSS climb observed when repeatedly calling `get_active_window_info()`.

### 2. Hook lifecycle fix

In `src/macos.rs`, the macOS hook paths now:

- reuse the Objective-C observer classes instead of trying to recreate them
- remove `NSWorkspace` observers on shutdown/restart
- remove AX notifications when observers are replaced or torn down
- release AX observer/application objects and callback handler allocations correctly
- clean up the `window-only` and `combined` observer lifecycle consistently

This addresses the repeated hook start/stop growth and the early failure when cycling the combined hook.

## Manual regression targets

This PR adds two manual regression targets:

- `examples/macos_memory_diagnostics.rs`
- `tests/macos_active_window_query_memory.rs`

Notes:

- the example is the main manual diagnostics harness for both query and hook paths
- the test is intentionally `#[ignore]`
- both require a real macOS foreground GUI session and Accessibility permission
- these are intended as manual regression targets, not CI-stable automated checks

## Before / after results

### Query path

Command:

```sh
cargo run --release --example macos_memory_diagnostics -- \
  --mode query-loop \
  --iterations 50000 \
  --sample-every 1000 \
  --query-sleep-ms 1
```

Before fix:

- final `rss_delta_mb=31.938`

Representative log lines:

```text
starting mode=QueryLoop pid=6384 monitor=Combined embed_active_info=true iterations=50000 sample_every=1000
tip: compare before/after fix with the same command and watch rss_mb / rss_delta_mb
sample label=query-loop iteration=1000 elapsed_s=2.881 rss_mb=12.141 rss_delta_mb=5.000 query_ok=1000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=2000 elapsed_s=5.467 rss_mb=12.812 rss_delta_mb=5.672 query_ok=2000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
...
sample label=query-loop iteration=49000 elapsed_s=170.177 rss_mb=38.812 rss_delta_mb=31.672 query_ok=49000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=50000 elapsed_s=173.662 rss_mb=39.359 rss_delta_mb=32.219 query_ok=50000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
```

After fix:

- final `rss_delta_mb=4.156`

Observed behavior after fix:

- RSS rises during warmup only
- RSS then stays effectively flat for the remainder of the 50k-iteration run

Representative log lines:

```text
starting mode=QueryLoop pid=79276 monitor=Combined embed_active_info=true iterations=50000 sample_every=1000
tip: compare before/after fix with the same command and watch rss_mb / rss_delta_mb
sample label=query-loop iteration=1000 elapsed_s=3.336 rss_mb=11.219 rss_delta_mb=4.047 query_ok=1000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=2000 elapsed_s=7.094 rss_mb=11.266 rss_delta_mb=4.094 query_ok=2000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=3000 elapsed_s=10.684 rss_mb=11.281 rss_delta_mb=4.109 query_ok=3000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
...
sample label=query-loop iteration=48000 elapsed_s=187.147 rss_mb=11.328 rss_delta_mb=4.156 query_ok=48000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=49000 elapsed_s=190.943 rss_mb=11.328 rss_delta_mb=4.156 query_ok=49000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=50000 elapsed_s=195.074 rss_mb=11.328 rss_delta_mb=4.156 query_ok=50000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
sample label=query-loop iteration=50000 elapsed_s=195.076 rss_mb=11.328 rss_delta_mb=4.156 query_ok=50000 query_err=0 hook_ok=0 hook_err=0 stop_attempts=0 stop_retries=0 app_changes=0 window_changes=0 app_info=0 window_info=0
```

### Hook path

Command:

```sh
cargo run --release --example macos_memory_diagnostics -- \
  --mode hook-cycle \
  --iterations 2000 \
  --sample-every 100 \
  --monitor combined \
  --embed-active-info true \
  --hook-run-ms 250 \
  --cooldown-ms 50
```

Before fix:

- failed at cycle 2
- `hook_ok=1`
- `hook_err=1`
- error: `Failed to create observer class`

Representative log lines:

```text
starting mode=HookCycle pid=26466 monitor=Combined embed_active_info=true iterations=2000 sample_every=100
tip: compare before/after fix with the same command and watch rss_mb / rss_delta_mb
sample label=hook-cycle iteration=2 elapsed_s=0.558 rss_mb=10.000 rss_delta_mb=2.812 query_ok=0 query_err=0 hook_ok=1 hook_err=1 stop_attempts=1 stop_retries=0 app_changes=2 window_changes=0 app_info=0 window_info=0
sample label=hook-cycle iteration=2 elapsed_s=0.559 rss_mb=10.031 rss_delta_mb=2.844 query_ok=0 query_err=0 hook_ok=1 hook_err=1 stop_attempts=1 stop_retries=0 app_changes=2 window_changes=0 app_info=0 window_info=0
```

After fix:

- completed all 2000 cycles
- final `hook_ok=2000`
- final `hook_err=0`
- final `rss_delta_mb=9.047`

Observed behavior after fix:

- no early hook lifecycle failure
- app/window callback counts remain roughly aligned with cycle count
- combined-mode repeated hook cycling stays bounded enough to complete the full run

Representative log lines:

```text
starting mode=HookCycle pid=84201 monitor=Combined embed_active_info=true iterations=2000 sample_every=100
tip: compare before/after fix with the same command and watch rss_mb / rss_delta_mb
sample label=hook-cycle iteration=100 elapsed_s=30.666 rss_mb=14.266 rss_delta_mb=7.109 query_ok=0 query_err=0 hook_ok=100 hook_err=0 stop_attempts=100 stop_retries=0 app_changes=102 window_changes=65 app_info=2 window_info=4
sample label=hook-cycle iteration=200 elapsed_s=61.366 rss_mb=14.375 rss_delta_mb=7.219 query_ok=0 query_err=0 hook_ok=200 hook_err=0 stop_attempts=200 stop_retries=0 app_changes=203 window_changes=166 app_info=3 window_info=5
sample label=hook-cycle iteration=300 elapsed_s=92.001 rss_mb=14.562 rss_delta_mb=7.406 query_ok=0 query_err=0 hook_ok=300 hook_err=0 stop_attempts=300 stop_retries=0 app_changes=305 window_changes=265 app_info=5 window_info=7
...
sample label=hook-cycle iteration=1800 elapsed_s=552.343 rss_mb=15.953 rss_delta_mb=8.797 query_ok=0 query_err=0 hook_ok=1800 hook_err=0 stop_attempts=1800 stop_retries=0 app_changes=1805 window_changes=1764 app_info=5 window_info=7
sample label=hook-cycle iteration=1900 elapsed_s=583.154 rss_mb=16.141 rss_delta_mb=8.984 query_ok=0 query_err=0 hook_ok=1900 hook_err=0 stop_attempts=1900 stop_retries=0 app_changes=1909 window_changes=1868 app_info=9 window_info=11
sample label=hook-cycle iteration=2000 elapsed_s=613.876 rss_mb=16.203 rss_delta_mb=9.047 query_ok=0 query_err=0 hook_ok=2000 hook_err=0 stop_attempts=2000 stop_retries=0 app_changes=2009 window_changes=1968 app_info=9 window_info=11
sample label=hook-cycle iteration=2000 elapsed_s=613.927 rss_mb=16.203 rss_delta_mb=9.047 query_ok=0 query_err=0 hook_ok=2000 hook_err=0 stop_attempts=2000 stop_retries=0 app_changes=2009 window_changes=1968 app_info=9 window_info=11
```

## Files of interest

- `src/macos.rs`
- `examples/macos_memory_diagnostics.rs`
- `tests/macos_active_window_query_memory.rs`

## Testing

Manually verified on macOS with Accessibility permission enabled:

- `cargo test --test macos_active_window_query_memory --no-run`
- query-loop before/after comparison
- combined hook-cycle before/after comparison
